### PR TITLE
module: build on 7.1, 7.2 and 7.3 from one source; check-audio: accept extra/

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Working **stereo** on the internal speakers of the ASUS ProArt PX13 (HN7306*,
 AMD Strix Halo) — on a **stock kernel ≥ 7.1**, surviving kernel and
 alsa-ucm-conf updates.
 
-**Kernel 7.2 users:** the DKMS module had to be rebased — upstream changed
-`sdca_parse_function()` and the old source no longer compiled, so the build
-failed and the *stock* driver silently took over (stereo gone). Pull and re-run
+**Kernel 7.1 / 7.2 / 7.3 users:** one module source now builds on all three
+(`LINUX_VERSION_CODE` guards cover the two SoundWire/SDCA calls that changed
+shape). If an earlier checkout left you with a failed DKMS build and the
+*stock* driver silently taking over (stereo gone), pull and re-run
 `bash install-durable.sh`, then `bash check-audio.sh`. Details in
 [Kernel updates](#kernel-updates-what-breaks-and-how-to-tell).
 
@@ -16,9 +17,10 @@ at install time (`lib/px13-detect.sh`), and the installer now **fails loudly**
 instead of exiting 0 without sound. See
 [SKU independence](#sku-independence-why-it-used-to-break-on-other-px13s).
 
-Tested on CachyOS `linux-cachyos` 7.1.3, 7.1.8 and 7.2.2 (HN7306EAC) and
-reported working on HN7306EA / HN7306EA-LX005X. The module also compiles
-against 7.3-rc1. Should work on Arch, Fedora and other distros with minor path
+Tested on CachyOS `linux-cachyos` 7.1.3, 7.1.8 and 7.2.2 and Fedora 44
+7.1.12 (HN7306EAC) and reported working on HN7306EA / HN7306EA-LX005X. The
+module compiles clean against Fedora's 7.1.12, 7.1.13, 7.2.3 and 7.3.0-rc1
+kernel-devel trees. Should work on Arch, Fedora and other distros with minor path
 adjustments — the build follows whatever toolchain the target kernel was built
 with (clang on CachyOS, gcc on Arch stock and Fedora), so no manual `LLVM=1`.
 
@@ -144,8 +146,9 @@ on an API that moves. Twice now an update has degraded the audio **silently**:
 
 | Kernel | What changed | What you saw |
 |---|---|---|
-| 7.2 | `sdca_parse_function()` gained a `struct sdw_slave *` parameter | DKMS build failed during the pacman transaction, the **stock** module loaded instead, `Channel Playback` disappeared → mono from one speaker |
-| 7.3-rc1 | the same function *lost* that parameter again | same, if built from the 7.2 source |
+| 7.2 | `sdca_parse_function()` lost its `struct sdca_function_desc *` parameter (now read from `function_data->desc`), and resume moved to a new `sdw_slave_wait_for_init()` helper | DKMS build failed during the pacman transaction, the **stock** module loaded instead, `Channel Playback` disappeared → mono from one speaker |
+| 7.3-rc1 | the same function also lost its `struct sdw_slave *` parameter | same, if built from the 7.2 source |
+| 7.1 (after the 7.2 rebase) | a 7.2-only source has neither the 7.1 `sdca_parse_function()` shape nor `sdw_slave_wait_for_init()` | same again, on any distro still shipping 7.1.y (Fedora 44 at the time of writing) |
 | 7.2 | the kernel started tagging the card `spk:tas2783` — while `alsa-ucm-conf` (1.2.16.1) still ships no tas2783 config | on a machine **without** this repo, worse than 7.1: UCM cannot open the card at all instead of silently skipping the Speaker device |
 | (any) | a driver swap under a live WirePlumber | the stored per-route volume can come back at **0%** — sink unmuted, HiFi active, `paplay` exits 0, and nothing comes out |
 
@@ -155,7 +158,7 @@ Nothing logs an error for either of these, which is why there is a checker:
 bash check-audio.sh
 ```
 
-It verifies the four invariants — patched module in `updates/`, DKMS built for
+It verifies the four invariants — patched module in `updates/` (`extra/` on Fedora), DKMS built for
 the running kernel, both amps on different channels, and a speaker sink that is
 neither muted nor at 0% — and prints the exact command to fix each one. Run it
 after every kernel update; exit code is non-zero if anything is off.
@@ -172,8 +175,9 @@ The proper upstream fix for this half now belongs in **alsa-ucm-conf**, not the
 kernel: a `sof-soundwire/tas2783.conf` and `codecs/tas2783/` upstream would
 retire two of the three files here.
 
-The module now carries a `LINUX_VERSION_CODE` guard on that call and builds
-clean on 7.2 and 7.3-rc1. Upstream 7.2 also absorbed two of the three local
+The module now carries `LINUX_VERSION_CODE` guards on that call and on the
+resume wait (a copy of 7.2's `sdw_slave_wait_for_init()` inline for 7.1), and
+builds clean on 7.1.12, 7.1.13, 7.2.3 and 7.3.0-rc1. Upstream 7.2 also absorbed two of the three local
 patches (the `tas25xx_*_misc` stubs and the `0x` firmware-name prefix, which
 upstream implemented better, with a fallback), so **the entire local delta is
 now the single `Channel Playback` control** — 31 lines over stock.
@@ -228,7 +232,7 @@ Everything is logged to `/var/log/px13-soundwire-resume.log`.
 
 | File (repo) | Installed to | Purpose |
 |---|---|---|
-| `module/` | `/usr/src/snd-soc-tas2783-sdw-px13-1.0` (DKMS) | Stock 7.1.y tas2783 driver + `Channel Playback` control |
+| `module/` | `/usr/src/snd-soc-tas2783-sdw-px13-1.0` (DKMS) | Stock 7.2.y tas2783 driver + `Channel Playback` control, version-guarded for 7.1 and 7.3 |
 | `configs/ucm-card-override.conf.in` | `/usr/share/alsa/ucm2/conf.d/<CardDriver>/<CardLongName>.conf` — **both probed**, template placeholders substituted at install time | Forces the speaker codec; **unowned by any package** → survives `alsa-ucm-conf` updates |
 | `lib/px13-detect.sh` | `/usr/local/lib/px13-audio-detect.sh` | Runtime probes: card, driver, long name, amp count, ACP PCI, PipeWire names |
 | `check-audio.sh` | — | Post-update health check; non-zero exit if any invariant broke |
@@ -242,8 +246,8 @@ Everything is logged to `/var/log/px13-soundwire-resume.log`.
 
 The DKMS module is the stock `linux-7.2.y` `tas2783-sdw.c` with one functional
 addition — nealstar's channel-selection control rebased onto the upstream
-driver (plus a `LINUX_VERSION_CODE` guard on the one call whose signature
-differs on 7.3+):
+driver (plus `LINUX_VERSION_CODE` guards for 7.1 and 7.3, where two of the
+APIs it uses differ):
 
 ```
 tas2783-N Channel Playback : enum { Off, Left, Right }
@@ -261,7 +265,7 @@ Without it both amps stay at the boot value `0x01` written by
 ```bash
 uname -r                                   # stock kernel, >= 7.1
 modinfo -k $(uname -r) snd_soc_tas2783_sdw -F filename
-#   -> .../updates/... (the DKMS/patched module, not .../kernel/sound/...)
+#   -> .../updates/... or .../extra/... (the DKMS/patched module, not .../kernel/sound/...)
 
 C=$(awk '/soundwire/ && /^ *[0-9]+ \[/ {print $1; exit}' /proc/asound/cards)
 alsaucm -c "$C" list _devices/HiFi | grep Speaker      # must print "Speaker"

--- a/check-audio.sh
+++ b/check-audio.sh
@@ -22,9 +22,11 @@ CARD="$(px13_find_card)" || { bad "SoundWire card present" "no card in /proc/aso
 ok "SoundWire card present (card $CARD, $(px13_card_longname "$CARD" || echo '?'))"
 
 # 1. the patched module, not the stock one -----------------------------------
+# DKMS drops it in updates/ on Arch and in extra/ on Fedora; both outrank the
+# in-tree copy under kernel/ in depmod's search order.
 MODPATH="$(modinfo -k "$(uname -r)" snd_soc_tas2783_sdw -F filename 2>/dev/null)"
 case "$MODPATH" in
-  */updates/*) ok "patched module installed ($MODPATH)" ;;
+  */updates/*|*/extra/*) ok "patched module installed ($MODPATH)" ;;
   "")          bad "patched module installed" "snd_soc_tas2783_sdw not found for this kernel" ;;
   *)           bad "patched module installed" "stock module in use ($MODPATH).
            A kernel update rebuilt nothing. Check: dkms status

--- a/module/tas2783-sdw.c
+++ b/module/tas2783-sdw.c
@@ -40,6 +40,32 @@
 
 #include "tas2783.h"
 
+/*
+ * sdw_slave_wait_for_init() only exists from 7.2 (a static inline in
+ * <linux/soundwire/sdw.h>). Carry a copy of it for 7.1 so the same resume
+ * path builds on every kernel this repo supports.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 2, 0)
+static inline int sdw_slave_wait_for_init(struct sdw_slave *slave, int timeout_ms)
+{
+	unsigned long time;
+
+	if (!slave)
+		return 0;
+
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+					   msecs_to_jiffies(timeout_ms));
+	if (!time) {
+		dev_err(&slave->dev, "Initialization not complete\n");
+		return -ETIMEDOUT;
+	}
+
+	slave->unattach_request = 0;
+
+	return 0;
+}
+#endif
+
 #define TIMEOUT_FW_DL_MS (3000)
 #define FW_DL_OFFSET	84 /* binary file information */
 #define FW_FL_HDR	20 /* minimum number of bytes in one chunk */
@@ -1357,13 +1383,18 @@ static s32 tas_sdw_probe(struct sdw_slave *peripheral,
 
 		/* Parse the function */
 		/*
-		 * sdca_parse_function() dropped its struct sdw_slave argument in
-		 * 7.3 (it reaches the peripheral through function_data->desc).
+		 * sdca_parse_function() changed shape twice: 7.1 takes the
+		 * function descriptor as its own argument, 7.2 reads it from
+		 * function_data->desc, and 7.3 also dropped the struct sdw_slave
+		 * argument (it reaches the peripheral through the descriptor).
 		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
 		ret = sdca_parse_function(dev, function_data);
-#else
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
 		ret = sdca_parse_function(dev, peripheral, function_data);
+#else
+		ret = sdca_parse_function(dev, peripheral, function_data->desc,
+					  function_data);
 #endif
 		if (!ret)
 			tas_dev->sa_func_data = function_data;


### PR DESCRIPTION
## Summary

The 7.2 rebase (53b04a3) left distros still on 7.1.y without a working build. Fedora 44 ships 7.1.12/7.1.13, and against those headers the module fails on the two calls that changed between 7.1 and 7.2:

- `sdw_slave_wait_for_init()` does not exist before 7.2 (it is a static inline in `<linux/soundwire/sdw.h>` from 7.2 on). This carries a copy of that inline under `LINUX_VERSION_CODE < 7.2` so the resume path is identical on every kernel.
- `sdca_parse_function()` took the function descriptor as its own argument on 7.1; 7.2 reads it from `function_data->desc`; 7.3 also dropped the `struct sdw_slave` argument. The existing 7.3 guard becomes a three-way one.

Same silent failure mode as the one that motivated the rebase: DKMS leaves the module "added", the stock driver loads, `Channel Playback` disappears, mono from one speaker.

Also:

- **check-audio.sh**: Fedora's dkms installs to `/lib/modules/<k>/extra/`, not `updates/`, so the "patched module installed" invariant reported the DKMS build as the stock driver. Accept both directories; depmod ranks each ahead of the in-tree `kernel/` copy.
- **README**: describe the 7.1 / 7.2 / 7.3 API differences accurately (7.2 removed the descriptor argument, 7.3 removed the `sdw_slave` one, not the other way round) and list the kernels the module is verified against.

## Verification

Builds clean, no warnings, against Fedora `kernel-devel` for:

| Kernel | Source |
|---|---|
| 7.1.12-200.fc44 | installed |
| 7.1.13-200.fc44 | installed |
| 7.2.3-300.fc44 | kojipkgs |
| 7.3.0-0.rc1.260903g940de590b839.21.fc46 | kojipkgs |

Stereo confirmed and `check-audio.sh` all-PASS on Fedora 44 / 7.1.12, HN7306EAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYmq4s7zTtYzn1YrGaqKks
